### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+os:
+    - linux
+    - osx
+
+dist: xenial
+
+sudo: required
+
+language: cpp
+
+before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
+
+install:
+    # Workaround for unavailability of libtins >4.0 on Ubuntu Xenial
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sed -i 's/\<libtins\-dev\>//g' resources/install_dependencies.sh; fi
+    - ./resources/install_dependencies.sh
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget "https://github.com/mfontanini/libtins/archive/v4.1.tar.gz"; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar -xf v4.1.tar.gz; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd libtins-4.1; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir build; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd build; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cmake ../ -DLIBTINS_ENABLE_CXX11=1; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make -j2; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo make install; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd ../../; fi
+
+script:
+    - ./build.sh --non-interactive
+    - ./run_tests

--- a/resources/install_dependencies.sh
+++ b/resources/install_dependencies.sh
@@ -2,7 +2,7 @@
 
 install_pkg_arch()
 {
-    PACMAN_PKGS="cmake python python-pip sqlite tcpdump"
+    PACMAN_PKGS="cmake python python-pip sqlite tcpdump cairo"
 
     # Check first to avoid unnecessary sudo
     echo -e "Packages: Checking..."
@@ -43,7 +43,7 @@ install_pkg_arch()
 
 install_pkg_ubuntu()
 {
-    APT_PKGS='build-essential cmake python3-dev python3-pip python3-venv sqlite tcpdump libtins-dev libpcap-dev'
+    APT_PKGS='build-essential cmake python3-dev python3-pip python3-venv sqlite tcpdump libtins-dev libpcap-dev libcairo2-dev'
 
     which sudo >/dev/null
     if [ $? != 0 ]; then
@@ -67,7 +67,7 @@ install_pkg_ubuntu()
 
 install_pkg_darwin()
 {
-    BREW_PKGS="cmake python coreutils libdnet libtins sqlite"
+    BREW_PKGS="cmake python coreutils libdnet libtins sqlite cairo"
 
     # Check first to avoid unnecessary update
     echo -e "Packages: Checking..."


### PR DESCRIPTION
This adds a configuration file for Travis CI (Travis needs to get enabled too for this to work), which builds and tests ID2T on Ubuntu 16.04 and macOS. On macOS, the current libtins is already available, on Ubuntu, we currently build libtins 4.1 manually (this can be removed once Travis provides an Ubuntu image with an up to date version of libtins).

You can see what the result looks like here: https://travis-ci.org/thrimbor/ID2T