### PR TITLE
Fix macOS build by forcing homebrew to upgrade packages

### DIFF
--- a/resources/install_dependencies.sh
+++ b/resources/install_dependencies.sh
@@ -85,6 +85,8 @@ install_pkg_darwin()
         # Install all missing packages
         echo -e "Packages: Installing..."
         brew install $BREW_PKGS
+        echo -e "Packages: Upgrading..."
+        brew upgrade $BREW_PKGS
     else
         echo -e "Packages: Found."
     fi


### PR DESCRIPTION
Homebrew seems have upgraded readline recently (which we pull in as a requirement for libdnet, which is required for scapy), breaking compatibility with old versions of Python 3. Since homebrew does not automatically upgrade outdated packages when using "brew install", this broke the build for Travis CI, as well as all macOS users that didn't upgrade their Python package manually.

This commit fixes that by running "brew upgrade" for all homebrew packages we require directly after running "brew install", which makes homebrew upgrade the packages that were installed already. Unfortunately, this slows down the macOS Travis CI build even more, but at least it works again.